### PR TITLE
投稿機能の作成（完成）

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the posts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,65 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px; }
+
+body, p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px; }
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px; }
+
+a {
+  color: #000; }
+
+a:visited {
+  color: #666; }
+
+a:hover {
+  color: #fff;
+  background-color: #000; }
+
+th {
+  padding-bottom: 5px; }
+
+td {
+  padding: 0 5px 7px; }
+
+div.field,
+div.actions {
+  margin-bottom: 10px; }
+
+#notice {
+  color: green; }
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table; }
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0; }
+
+#error_explanation h2 {
+  text-align: left;
+  font-weight: bold;
+  padding: 5px 5px 5px 15px;
+  font-size: 12px;
+  margin: -7px -7px 0;
+  background-color: #c00;
+  color: #fff; }
+
+#error_explanation ul li {
+  font-size: 12px;
+  list-style: square; }
+
+label {
+  display: block; }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,76 @@
+class PostsController < ApplicationController
+  before_action :set_post, only: %i[ show edit update destroy ]
+
+  # GET /posts or /posts.json
+  def index
+    @posts = Post.all
+  end
+
+  # GET /posts/1 or /posts/1.json
+  def show
+  end
+
+  # GET /posts/new
+  def new
+    @post = Post.new
+  end
+
+  # GET /posts/1/edit
+  def edit
+  end
+
+  # POST /posts or /posts.json
+  def create
+    @post = Post.new(post_params)
+    # user_idの情報はフォームからはきていないので、deviseのメソッドを使って「ログインしている自分のid」を代入
+    @post.user_id = current_user.id
+
+    respond_to do |format|
+      if @post.save
+        format.html { redirect_to @post, notice: "投稿しました." }
+        format.json { render :show, status: :created, location: @post }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @post.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /posts/1 or /posts/1.json
+  def update
+    respond_to do |format|
+      if @post.update(post_params)
+        format.html { redirect_to @post, notice: "Post was successfully updated." }
+        format.json { render :show, status: :ok, location: @post }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @post.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /posts/1 or /posts/1.json
+  def destroy
+    @post.destroy
+    respond_to do |format|
+      format.html { redirect_to posts_url, notice: "Post was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_post
+      @post = Post.find(params[:id])
+    end
+
+    # 受け取るparamsは、contentのみ
+    def post_params
+      params.require(:post).permit(:content)
+    end
+
+    # private
+    # def post_params
+    #   params.require(:post).permit(:body) # tweetモデルのカラムのみを許可
+    # end
+end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,8 @@
+class Post < ApplicationRecord
+
+    # 1対多のリレーション付け
+    belongs_to :user
+
+    validates :user_id, {presence: true}
+    validates :content, {presence: true}
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,8 @@
 class User < ApplicationRecord
+
+  # 1対多のリレーション付け
+  has_many :posts, dependent: :destroy
+  
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,9 @@
           <% if user_signed_in? %>
             <%= link_to("#{current_user.username}さんのページ", "/pages/show") %>
             <%= link_to 'プロフィール変更', edit_user_registration_path %>
+            <%= link_to("投稿","/posts/new") %>
+            <%# ↓↓↓↓　　リンク先、修正必要　　↓↓↓↓ %>
+            <%= link_to("投稿一覧","/posts/#{current_user.id}") %> 
             <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
           <% else %>
             <%= link_to 'サインアップ', new_user_registration_path %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: post, local: true) do |form| %>
+  <% if post.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(post.errors.count, "error") %> 投稿できませんでした</h2>
+
+      <ul>
+        <% post.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :内容 %>
+    <%= form.text_field :content %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/posts/_post.json.jbuilder
+++ b/app/views/posts/_post.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! post, :id, :user_id, :content, :created_at, :updated_at
+json.url post_url(post, format: :json)

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Post</h1>
+
+<%= render 'form', post: @post %>
+
+<%= link_to '投稿詳細', @post %> |
+<%= link_to '戻る', posts_path %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>投稿一覧</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>ユーザー</th>
+      <th>内容</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @posts.each do |post| %>
+      <tr>
+        <td><%= post.user_id %></td>
+        <td><%= post.content %></td>
+        <td><%= link_to '投稿詳細', post %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to '新規投稿', new_post_path %>

--- a/app/views/posts/index.json.jbuilder
+++ b/app/views/posts/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @posts, partial: "posts/post", as: :post

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,5 @@
+<h1>新規投稿</h1>
+
+<%= render 'form', post: @post %>
+
+<%= link_to '戻る', posts_path %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>User:</strong>
+  <%= @post.user_id %>
+</p>
+
+<p>
+  <strong>Content:</strong>
+  <%= @post.content %>
+</p>
+
+<%= link_to '編集', edit_post_path(@post) %> |
+<% if @post.user_id == current_user.id %>
+<%= link_to '編集', edit_post_path(@post) %> |
+<%= link_to '削除', @post, method: :delete, data: { confirm: '本当に削除してよろしいですか?' } %> |
+<% end %>
+<%= link_to '戻る', posts_path %>
+

--- a/app/views/posts/show.json.jbuilder
+++ b/app/views/posts/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "posts/post", post: @post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :posts
   devise_for :users
   root 'pages#index'
   get 'pages/show'

--- a/db/migrate/20210314023445_create_posts.rb
+++ b/db/migrate/20210314023445_create_posts.rb
@@ -1,0 +1,10 @@
+class CreatePosts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :posts do |t|
+      t.integer :user_id
+      t.string :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_13_100144) do
+ActiveRecord::Schema.define(version: 2021_03_14_023445) do
+
+  create_table "posts", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @post = posts(:one)
+  end
+
+  test "should get index" do
+    get posts_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_post_url
+    assert_response :success
+  end
+
+  test "should create post" do
+    assert_difference('Post.count') do
+      post posts_url, params: { post: { content: @post.content, user_id: @post.user_id } }
+    end
+
+    assert_redirected_to post_url(Post.last)
+  end
+
+  test "should show post" do
+    get post_url(@post)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_post_url(@post)
+    assert_response :success
+  end
+
+  test "should update post" do
+    patch post_url(@post), params: { post: { content: @post.content, user_id: @post.user_id } }
+    assert_redirected_to post_url(@post)
+  end
+
+  test "should destroy post" do
+    assert_difference('Post.count', -1) do
+      delete post_url(@post)
+    end
+
+    assert_redirected_to posts_url
+  end
+end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  content: MyString
+
+two:
+  user_id: 1
+  content: MyString

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/posts_test.rb
+++ b/test/system/posts_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class PostsTest < ApplicationSystemTestCase
+  setup do
+    @post = posts(:one)
+  end
+
+  test "visiting the index" do
+    visit posts_url
+    assert_selector "h1", text: "Posts"
+  end
+
+  test "creating a Post" do
+    visit posts_url
+    click_on "New Post"
+
+    fill_in "Content", with: @post.content
+    fill_in "User", with: @post.user_id
+    click_on "Create Post"
+
+    assert_text "Post was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Post" do
+    visit posts_url
+    click_on "Edit", match: :first
+
+    fill_in "Content", with: @post.content
+    fill_in "User", with: @post.user_id
+    click_on "Update Post"
+
+    assert_text "Post was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Post" do
+    visit posts_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Post was successfully destroyed"
+  end
+end


### PR DESCRIPTION
【目的】
投稿機能の実装

【やったこと】
scaffold を利用してpostの簡単な機能を実装（https://techacademy.jp/magazine/7204）

postとuserの紐付け。ユーザーを削除するとそのユーザーの投稿も一緒に削除されるようにする（https://qiita.com/hak_chami/items/336a366ce0071e2f92f9）
（https://qiita.com/kazukimatsumoto/items/14bdff681ec5ddac26d1）