### PR TITLE
画像の複数枚添付（完成）

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -66,7 +66,7 @@ class PostsController < ApplicationController
 
     # 受け取るparamsは、contentのみ
     def post_params
-      params.require(:post).permit(:content, :image)
+      params.require(:post).permit(:content, images: []) # []をつけることで複数の画像データが入ることができる配列型のデータになる
     end
 
     # private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,7 +4,7 @@ class Post < ApplicationRecord
     belongs_to :user
 
     # post は１つの画像をもつ ことのリレーション付け
-    has_one_attached :image # activeStorageではpostテーブルにimageカラムを追加する必要はない
+    has_many_attached :images # activeStorageではpostテーブルにimageカラムを追加する必要はない
 
     validates :user_id, {presence: true}
     validates :content, {presence: true}

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -21,7 +21,7 @@
 
       <div class="field">
         <%= form.label :画像 %>
-        <%= form.file_field :image %>
+        <%= form.file_field :images, direct_upload: true, multiple: true %> <%# multiple: true で複数画像を投稿できるようにしている %>
       </div>
 
       <div class="actions">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,7 +14,9 @@
 
     <div class="image p-3">
       <% # 投稿の画像をサイズ変更して表示 %>
-      <%= image_tag @post.image.variant(resize:'350x350') %>
+      <% @post.images.each do |image| %>
+        <%= image_tag image.variant(resize: '350x350') %>
+      <% end %>
     </div>
 
     <div class="p-3">


### PR DESCRIPTION
【目的】
投稿時の画像の複数枚添付

【やったこと】
リレーション付けをhas_many_attachedに変更
formからpermitをimages: [] にして、複数の画像データが入るようにした
ビュー上で、each文を使い、複数画像を表示できるようにした

↓↓↓参考元↓↓↓
https://qiita.com/me-654393/items/3b259bbc70f62898bd6f
https://techtechmedia.com/active-storage-rails6/